### PR TITLE
refactor: update jest for typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,17 @@
 		"puppeteer": "^8.0.0"
 	},
 	"devDependencies": {
+		"@jest/environment": "^29.5.0",
+		"@jest/expect": "^29.5.0",
+		"@jest/globals": "^29.5.0",
+		"@jest/types": "^29.5.0",
 		"@types/jest": "^26.0.20",
 		"@types/puppeteer": "^5.4.3",
+		"jest": "^29.5.0",
+		"jest-config": "^29.5.0",
+		"jest-mock": "^29.5.0",
 		"prettier": "^2.2.1",
-		"ts-jest": "^26.5.2",
+		"ts-jest": "^29.1.1",
 		"typescript": "^4.2.2"
 	}
 }

--- a/test/error.test.ts
+++ b/test/error.test.ts
@@ -1,5 +1,6 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import { translateDocs, translateText } from '../src/index';
 import { Options } from '../src/types';
-import { translateText, translateDocs } from '../src/index';
 
 const opt: Options = { to: 'eo', headless: false };
 
@@ -7,14 +8,10 @@ jest.setTimeout(10000);
 
 describe('fileSize', () => {
 	test('docs', async () => {
-		await expect(
-			translateDocs('./test/assets/limit.txt', opt)
-		).rejects.toThrow();
+		await expect(translateDocs('./test/assets/limit.txt', opt)).rejects.toThrow();
 	});
 	test('docsArray', async () => {
-		await expect(
-			translateDocs(['./test/assets/limit.txt'], opt)
-		).rejects.toThrow();
+		await expect(translateDocs(['./test/assets/limit.txt'], opt)).rejects.toThrow();
 	});
 });
 
@@ -23,9 +20,7 @@ describe('fileType', () => {
 		await expect(translateDocs('./test/assets/err.err', opt)).rejects.toThrow();
 	});
 	test('docsArray', async () => {
-		await expect(
-			translateDocs(['./test/assets/err.err'], opt)
-		).rejects.toThrow();
+		await expect(translateDocs(['./test/assets/err.err'], opt)).rejects.toThrow();
 	});
 });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,6 @@
+import { expect, jest, test } from '@jest/globals';
+import { translateDocs, translateText } from '../src/index';
 import { Options } from '../src/types';
-import { translateText, translateDocs } from '../src/index';
 
 const opt: Options = { to: 'es', headless: true };
 
@@ -21,9 +22,6 @@ test('docs', async () => {
 });
 
 test('docsArray', async () => {
-	const result = await translateDocs(
-		['./test/assets/txt.txt', './test/assets/docx.docx'],
-		opt
-	);
+	const result = await translateDocs(['./test/assets/txt.txt', './test/assets/docx.docx'], opt);
 	expect(result).toStrictEqual(['TXT', 'docx']);
 });


### PR DESCRIPTION
jest now supported for typescript, see more at https://jestjs.io/docs/getting-started#using-typescript